### PR TITLE
Adding initial test suite

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -42,8 +42,8 @@ jobs:
 
       - name: Run tests
         run: |
-	        include .env
-	        make unittest
+          include .env
+          make unittest
 
       - name: Surface failing tests
         if: always()

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -1,0 +1,76 @@
+---
+name: aep
+on:
+  pull_request:
+    branches: 
+      - 'main'
+
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+
+    env:
+      AZURE_VAULT_ID: ${{ secrets.TEST_AZURE_VAULT_ID }}
+      AZURE_CLIENT_ID: ${{ secrets.TEST_AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.TEST_AZURE_TENANT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.TEST_AZURE_CLIENT_SECRET }}
+      AZURE_OPENAI_ENDPOINT: ${{ secrets.TEST_AZURE_OPENAI_ENDPOINT }}
+      AZURE_OPENAI_KEY: ${{ secrets.TEST_AZURE_OPENAI_KEY }}
+      OPENAI_API_KEY: ${{ secrets.TEST_AZURE_OPENAI_KEY }}
+      AZURE_CS_ENDPOINT: ${{ secrets.TEST_AZURE_CS_ENDPOINT }}
+      AZURE_CS_KEY: ${{ secrets.TEST_AZURE_CS_KEY }}
+
+      SYSTEM_PROMPT_FILE: "system_prompts/prompts.json"
+      azure_openai_api_version: "2023-12-01-preview"
+      SYSTEM_API_KEY: "system"
+      OPENAI_API_TYPE: "azure"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f src/requirements.txt ]; then pip install -r src/requirements.txt; fi
+
+      - name: Run tests
+        working-directory: src/
+        run: |
+          pytest tests/ -vv -s --junit-xml=test-results.xml
+
+      - name: Surface failing tests
+        if: always()
+        uses: pmeier/pytest-results-action@main
+        with:
+          # A list of JUnit XML files, directories containing the former, and wildcard
+          # patterns to process.
+          # See @actions/glob for supported patterns.
+          path: src/test-results.xml
+      
+          # (Optional) Add a summary of the results at the top of the report
+          summary: true
+      
+          # (Optional) Select which results should be included in the report.
+          # Follows the same syntax as `pytest -r`
+          display-options: fEX
+      
+          # (Optional) Fail the workflow if no JUnit XML was found.
+          fail-on-empty: true
+      
+          # (Optional) Title of the test results section in the workflow summary
+          title: AEP Test Results
+
+        env:
+          CI: true

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -25,11 +25,24 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.TEST_AZURE_OPENAI_KEY }}
       AZURE_CS_ENDPOINT: ${{ secrets.TEST_AZURE_CS_ENDPOINT }}
       AZURE_CS_KEY: ${{ secrets.TEST_AZURE_CS_KEY }}
-
       SYSTEM_PROMPT_FILE: "system_prompts/prompts.json"
       azure_openai_api_version: "2023-12-01-preview"
       SYSTEM_API_KEY: "system"
       OPENAI_API_TYPE: "azure"
+    run: |
+          echo "AZURE_VAULT_ID=${AZURE_VAULT_ID}" >> .env
+          echo "AZURE_CLIENT_ID=${AZURE_CLIENT_ID}" >> .env
+          echo "AZURE_TENANT_ID=${AZURE_TENANT_ID}" >> .env
+          echo "AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET}" >> .env
+          echo "AZURE_OPENAI_ENDPOINT=${AZURE_OPENAI_ENDPOINT}" >> .env
+          echo "AZURE_OPENAI_KEY=${AZURE_OPENAI_KEY}" >> .env
+          echo "OPENAI_API_KEY=${OPENAI_API_KEY}" >> .env
+          echo "AZURE_CS_ENDPOINT=${AZURE_CS_ENDPOINT}" >> .env
+          echo "AZURE_CS_KEY=${AZURE_CS_KEY}" >> .env
+          echo "SYSTEM_PROMPT_FILE=${SYSTEM_PROMPT_FILE}" >> .env
+          echo "azure_openai_api_version=${azure_openai_api_version}" >> .env
+          echo "SYSTEM_API_KEY=${SYSTEM_API_KEY}" >> .env
+          echo "OPENAI_API_TYPE=${OPENAI_API_TYPE}" >> .env
 
     steps:
       - name: Checkout repository
@@ -42,7 +55,6 @@ jobs:
 
       - name: Run tests
         run: |
-          include .env
           make unittest
 
       - name: Surface failing tests

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: Run tests
         run: |
+          pwd
           make unittest
 
       - name: Surface failing tests

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -41,7 +41,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run tests
-        run: make unittest
+        run: |
+	        include .env
+	        make unittest
 
       - name: Surface failing tests
         if: always()

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -29,7 +29,11 @@ jobs:
       azure_openai_api_version: "2023-12-01-preview"
       SYSTEM_API_KEY: "system"
       OPENAI_API_TYPE: "azure"
-    run: |
+
+    steps:
+
+      - name: Create .env file
+        run: |
           echo "AZURE_VAULT_ID=${AZURE_VAULT_ID}" >> .env
           echo "AZURE_CLIENT_ID=${AZURE_CLIENT_ID}" >> .env
           echo "AZURE_TENANT_ID=${AZURE_TENANT_ID}" >> .env
@@ -43,8 +47,7 @@ jobs:
           echo "azure_openai_api_version=${azure_openai_api_version}" >> .env
           echo "SYSTEM_API_KEY=${SYSTEM_API_KEY}" >> .env
           echo "OPENAI_API_TYPE=${OPENAI_API_TYPE}" >> .env
-
-    steps:
+  
       - name: Checkout repository
         uses: actions/checkout@v2
 

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Create .env file
         run: |
+          pwd
           echo "AZURE_VAULT_ID=${AZURE_VAULT_ID}" >> .env
           echo "AZURE_CLIENT_ID=${AZURE_CLIENT_ID}" >> .env
           echo "AZURE_TENANT_ID=${AZURE_TENANT_ID}" >> .env

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -35,19 +35,19 @@ jobs:
       - name: Create .env file
         run: |
           pwd
-          echo "AZURE_VAULT_ID=${AZURE_VAULT_ID}" >> .env
-          echo "AZURE_CLIENT_ID=${AZURE_CLIENT_ID}" >> .env
-          echo "AZURE_TENANT_ID=${AZURE_TENANT_ID}" >> .env
-          echo "AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET}" >> .env
-          echo "AZURE_OPENAI_ENDPOINT=${AZURE_OPENAI_ENDPOINT}" >> .env
-          echo "AZURE_OPENAI_KEY=${AZURE_OPENAI_KEY}" >> .env
-          echo "OPENAI_API_KEY=${OPENAI_API_KEY}" >> .env
-          echo "AZURE_CS_ENDPOINT=${AZURE_CS_ENDPOINT}" >> .env
-          echo "AZURE_CS_KEY=${AZURE_CS_KEY}" >> .env
-          echo "SYSTEM_PROMPT_FILE=${SYSTEM_PROMPT_FILE}" >> .env
-          echo "azure_openai_api_version=${azure_openai_api_version}" >> .env
-          echo "SYSTEM_API_KEY=${SYSTEM_API_KEY}" >> .env
-          echo "OPENAI_API_TYPE=${OPENAI_API_TYPE}" >> .env
+          echo "AZURE_VAULT_ID=${AZURE_VAULT_ID}" >> ./.env
+          echo "AZURE_CLIENT_ID=${AZURE_CLIENT_ID}" >> ./.env
+          echo "AZURE_TENANT_ID=${AZURE_TENANT_ID}" >> ./.env
+          echo "AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET}" >> ./.env
+          echo "AZURE_OPENAI_ENDPOINT=${AZURE_OPENAI_ENDPOINT}" >> ./.env
+          echo "AZURE_OPENAI_KEY=${AZURE_OPENAI_KEY}" >> ./.env
+          echo "OPENAI_API_KEY=${OPENAI_API_KEY}" >> ./.env
+          echo "AZURE_CS_ENDPOINT=${AZURE_CS_ENDPOINT}" >> ./.env
+          echo "AZURE_CS_KEY=${AZURE_CS_KEY}" >> ./.env
+          echo "SYSTEM_PROMPT_FILE=${SYSTEM_PROMPT_FILE}" >> ./.env
+          echo "azure_openai_api_version=${azure_openai_api_version}" >> ./.env
+          echo "SYSTEM_API_KEY=${SYSTEM_API_KEY}" >> ./.env
+          echo "OPENAI_API_TYPE=${OPENAI_API_TYPE}" >> ./.env
   
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.12']
 
     env:
       AZURE_VAULT_ID: ${{ secrets.TEST_AZURE_VAULT_ID }}
@@ -40,15 +40,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          if [ -f src/requirements.txt ]; then pip install -r src/requirements.txt; fi
-
       - name: Run tests
-        working-directory: src/
-        run: |
-          pytest tests/ -vv -s --junit-xml=test-results.xml
+        working-directory: /
+        run: make unittest
 
       - name: Surface failing tests
         if: always()

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -75,7 +75,7 @@ jobs:
           display-options: fEX
       
           # (Optional) Fail the workflow if no JUnit XML was found.
-          fail-on-empty: true
+          fail-on-empty: false
       
           # (Optional) Title of the test results section in the workflow summary
           title: AEP Test Results

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -41,7 +41,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run tests
-        working-directory: /
         run: make unittest
 
       - name: Surface failing tests

--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -32,23 +32,6 @@ jobs:
 
     steps:
 
-      - name: Create .env file
-        run: |
-          pwd
-          echo "AZURE_VAULT_ID=${AZURE_VAULT_ID}" >> ./.env
-          echo "AZURE_CLIENT_ID=${AZURE_CLIENT_ID}" >> ./.env
-          echo "AZURE_TENANT_ID=${AZURE_TENANT_ID}" >> ./.env
-          echo "AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET}" >> ./.env
-          echo "AZURE_OPENAI_ENDPOINT=${AZURE_OPENAI_ENDPOINT}" >> ./.env
-          echo "AZURE_OPENAI_KEY=${AZURE_OPENAI_KEY}" >> ./.env
-          echo "OPENAI_API_KEY=${OPENAI_API_KEY}" >> ./.env
-          echo "AZURE_CS_ENDPOINT=${AZURE_CS_ENDPOINT}" >> ./.env
-          echo "AZURE_CS_KEY=${AZURE_CS_KEY}" >> ./.env
-          echo "SYSTEM_PROMPT_FILE=${SYSTEM_PROMPT_FILE}" >> ./.env
-          echo "azure_openai_api_version=${azure_openai_api_version}" >> ./.env
-          echo "SYSTEM_API_KEY=${SYSTEM_API_KEY}" >> ./.env
-          echo "OPENAI_API_TYPE=${OPENAI_API_TYPE}" >> ./.env
-  
       - name: Checkout repository
         uses: actions/checkout@v2
 
@@ -60,6 +43,19 @@ jobs:
       - name: Run tests
         run: |
           pwd
+          echo "AZURE_VAULT_ID=${AZURE_VAULT_ID}" >> .env
+          echo "AZURE_CLIENT_ID=${AZURE_CLIENT_ID}" >> .env
+          echo "AZURE_TENANT_ID=${AZURE_TENANT_ID}" >> .env
+          echo "AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET}" >> .env
+          echo "AZURE_OPENAI_ENDPOINT=${AZURE_OPENAI_ENDPOINT}" >> .env
+          echo "AZURE_OPENAI_KEY=${AZURE_OPENAI_KEY}" >> .env
+          echo "OPENAI_API_KEY=${OPENAI_API_KEY}" >> .env
+          echo "AZURE_CS_ENDPOINT=${AZURE_CS_ENDPOINT}" >> .env
+          echo "AZURE_CS_KEY=${AZURE_CS_KEY}" >> .env
+          echo "SYSTEM_PROMPT_FILE=${SYSTEM_PROMPT_FILE}" >> .env
+          echo "azure_openai_api_version=${azure_openai_api_version}" >> .env
+          echo "SYSTEM_API_KEY=${SYSTEM_API_KEY}" >> .env
+          echo "OPENAI_API_TYPE=${OPENAI_API_TYPE}" >> .env
           make unittest
 
       - name: Surface failing tests

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ mkdocs-build:
 run:
 	./buildscripts/run_docker.sh
 
+unittest:
+	$(MAKE) build-local
+	$(MAKE) run-tests
+
 run-tests:
 	./buildscripts/run_tests.sh
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -12,3 +12,4 @@ prometheus_fastapi_instrumentator
 pydantic-core
 pytest
 markdown
+coverage


### PR DESCRIPTION


























## 🤖AEP PR SUMMARY🤖


- Added a new file named `run-test-suite.yml` in the `.github/workflows` directory with a workflow for running tests on pull requests and manual triggers
- Updated the `Makefile` to include a new target `unittest` for building locally and running tests
- Modified `prompts.py` in the `src/helpers` directory to include debug logging for prompt injection and error handling for prompt injection detection
- Updated `requirements.txt` in the `src` directory to include a new dependency `coverage`