### PR TITLE
fix: add missing tf deploy pipeline

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -1,0 +1,75 @@
+# Workflow will deploy the terraform configuration to Azure
+name: Deploy to Azure
+
+# Triggers for the workflow
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  # Job to deploy the terraform configuration
+  terraform:
+    runs-on: ubuntu-latest
+    env:
+      ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+      BACKEND_RESOURCE_GROUP: ${{ secrets.BACKEND_RESOURCE_GROUP }}
+      BACKEND_STORAGE_ACCOUNT: ${{ secrets.BACKEND_STORAGE_ACCOUNT }}
+      BACKEND_CONTAINER_NAME: ${{ secrets.BACKEND_CONTAINER_NAME }}
+      SYSTEM_API_KEY: ${{ secrets.SYSTEM_API_KEY }}
+      DOCKER_REGISTRY_USERNAME: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+      DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+
+      TF_VERSION: 1.3.6
+
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Create a blank .env file for make
+      - name: Create a blank .env for make
+        run: |
+          touch .env
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: 'Terraform Lint Check'
+        run: |
+          make tf-fmt
+
+      # Auto commit changes after formatting
+      - name: Auto Commit Changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "Terraform fmt"
+          file_pattern: "*.tf"
+          commit_user_name: "github-actions[bot]"
+
+      - name: 'Terraform Init'
+        run: |
+          make tf-init
+
+      - name: 'Terraform Plan'
+        run: |
+          make tf-plan
+
+      - name: 'Terraform Apply'
+        if: github.event_name != 'pull_request'
+        run: |
+          make tf-apply


### PR DESCRIPTION
Adding missing terraform deployment pipeline from mirror repository.

## 🤖AEP PR SUMMARY🤖


- A new file `.github/workflows/deploy-terraform.yml` was added.
- This file contains a workflow to deploy to Azure triggered by pushes to the main branch, pull requests to the main branch, and manual dispatches.
- The job \"terraform\" is defined to run on Ubuntu latest, with several environment variables and default settings specified.
- Steps include code checkout, setting up Terraform, lint check, auto commit changes, Terraform initialization, and Terraform plan and apply.